### PR TITLE
Implement paginated document listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ python3 -m backlog_document_exporter.cli info <document_id>
 python3 -m backlog_document_exporter.cli download <document_id> <output_dir>
 ```
 
+The ``list`` command automatically fetches all pages of results using the
+required ``offset`` parameter of the Backlog API.
+
 `<document_id>` is the identifier shown in the list or tree output.
 
 All output except for downloaded files is printed in Markdown format.


### PR DESCRIPTION
## Summary
- fetch `/documents` with `offset` and `count`
- recursively retrieve all pages for a project
- mention automatic pagination in README

## Testing
- `python3 -m py_compile backlog_document_exporter/client.py backlog_document_exporter/cli.py`
- `pip3 install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_684c219881c4832a9348ecf463553f06