### PR TITLE
Add URL column to list output

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ python3 -m backlog_document_exporter.cli download <document_id> <output_dir>
 The ``list`` command automatically fetches all pages of results using the
 required ``offset`` parameter of the Backlog API.
 
+Each row in the ``list`` output also contains a ``url`` column pointing to the
+document in Backlog using the following format:
+
+```
+https://BACKLOG_SPACE_DOMAIN/document/BACKLOG_PROJECT_KEY/<document_id>
+```
+
 `<document_id>` is the identifier shown in the list or tree output.
 
 All output except for downloaded files is printed in Markdown format.

--- a/backlog_document_exporter/cli.py
+++ b/backlog_document_exporter/cli.py
@@ -18,7 +18,12 @@ def to_markdown_table(items: List[Dict[str, Any]], headers: List[str]) -> str:
 def print_document_list(client: BacklogClient) -> None:
     project_id = client.get_project_id()
     docs = client.get_document_list(project_id)
-    md = to_markdown_table(docs, ["id", "title"])
+    for doc in docs:
+        doc["url"] = (
+            f"https://{client.space_domain}/document/"
+            f"{client.project_key}/{doc['id']}"
+        )
+    md = to_markdown_table(docs, ["id", "title", "url"])
     print(md)
 
 


### PR DESCRIPTION
## Summary
- include an URL column when listing documents
- document the new column in the README

## Testing
- `python3 -m py_compile backlog_document_exporter/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684c23b75694832a9f8763c253c29f9f