### PR TITLE
Make output directory optional for download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ Activate the environment before using the commands below.
 python3 -m backlog_document_exporter.cli list
 python3 -m backlog_document_exporter.cli tree
 python3 -m backlog_document_exporter.cli info <document_id>
-python3 -m backlog_document_exporter.cli download <document_id> <output_dir>
+python3 -m backlog_document_exporter.cli download <document_id> [output_dir]
 ```
+
+If `output_dir` is omitted, files are saved to the current directory.
 
 The ``list`` command automatically fetches all pages of results using the
 required ``offset`` parameter of the Backlog API.

--- a/backlog_document_exporter/cli.py
+++ b/backlog_document_exporter/cli.py
@@ -62,7 +62,7 @@ def print_document_info(client: BacklogClient, document_id: str) -> None:
 
 
 def download_attachments(
-    client: BacklogClient, document_id: str, output_dir: str
+    client: BacklogClient, document_id: str, output_dir: str = "."
 ) -> None:
     os.makedirs(output_dir, exist_ok=True)
     attachments = client.get_document_attachments(document_id)
@@ -85,7 +85,12 @@ def main() -> None:
         "download", help="Download document attachments"
     )
     dl.add_argument("document_id")
-    dl.add_argument("output", help="Output directory")
+    dl.add_argument(
+        "output",
+        nargs="?",
+        default=".",
+        help="Output directory (default: current directory)",
+    )
 
     args = parser.parse_args()
 

--- a/backlog_document_exporter/client.py
+++ b/backlog_document_exporter/client.py
@@ -136,11 +136,16 @@ class BacklogClient:
     def get_document_attachments(
         self, document_id: str
     ) -> List[Dict[str, Any]]:
+        """Return a list of attachments for a document."""
         return self._request("GET", f"/documents/{document_id}/attachments")
 
     def download_attachment(
         self, document_id: str, attachment_id: int, output_dir: str
     ) -> str:
+        """Download an attachment.
+
+        Uses ``GET /api/v2/documents/:documentId/attachments/:attachmentId``.
+        """
         response = self._request(
             "GET",
             f"/documents/{document_id}/attachments/{attachment_id}",


### PR DESCRIPTION
## Summary
- document optional output directory for download command
- update CLI to allow omitted output directory
- clarify attachment download path in client

## Testing
- `python3 -m py_compile backlog_document_exporter/*.py`
- `python3 -m backlog_document_exporter.cli download 1` *(fails: BACKLOG_API_KEY, BACKLOG_PROJECT_KEY and BACKLOG_SPACE_DOMAIN must be set)*

------
https://chatgpt.com/codex/tasks/task_e_684c24e2bc50832ab1122c284fa034a9