### PR TITLE
Fix attachment filename handling

### DIFF
--- a/backlog_document_exporter/cli.py
+++ b/backlog_document_exporter/cli.py
@@ -67,7 +67,12 @@ def download_attachments(
     os.makedirs(output_dir, exist_ok=True)
     attachments = client.get_document_attachments(document_id)
     for att in attachments:
-        path = client.download_attachment(document_id, att["id"], output_dir)
+        path = client.download_attachment(
+            document_id,
+            att["id"],
+            output_dir,
+            filename=att.get("name"),
+        )
         print(f"Downloaded {att['name']} -> {path}")
 
 
@@ -81,9 +86,7 @@ def main() -> None:
     info = subparsers.add_parser("info", help="Show document info")
     info.add_argument("document_id")
 
-    dl = subparsers.add_parser(
-        "download", help="Download document attachments"
-    )
+    dl = subparsers.add_parser("download", help="Download document attachments")
     dl.add_argument("document_id")
     dl.add_argument(
         "output",


### PR DESCRIPTION
## Summary
- parse `filename*=` values when downloading document attachments
- allow overriding the filename when downloading
- use the attachment name from the document info when saving files

## Testing
- `pip install -r requirements.txt`
- `python -m backlog_document_exporter.cli --help`
- `black --check .`
- `python -m py_compile backlog_document_exporter/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c2990b600832a9efa334a11b6a399