### PR TITLE
Add document URLs to tree output

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ The `list` command automatically fetches all pages using the required `offset` p
 https://BACKLOG_SPACE_DOMAIN/document/BACKLOG_PROJECT_KEY/<document_id>
 ```
 
+The `tree` command prints a hierarchical view of the documents and appends the same URL after each document title.
+
 `<document_id>` is the identifier shown in the list or tree output. All command output other than downloaded files is printed in Markdown.
 
 ## Reference

--- a/backlog_document_exporter/cli.py
+++ b/backlog_document_exporter/cli.py
@@ -34,9 +34,15 @@ def print_document_tree(client: BacklogClient) -> None:
     def walk(nodes: List[Dict[str, Any]], indent: int = 0) -> List[str]:
         lines = []
         for node in nodes:
-            prefix = "  " * indent + "- " + node.get("name", "")
-            lines.append(prefix)
             children = node.get("children", [])
+            prefix = "  " * indent + "- " + node.get("name", "")
+            if not children and "id" in node:
+                url = (
+                    f"https://{client.space_domain}/document/"
+                    f"{client.project_key}/{node['id']}"
+                )
+                prefix += f" - {url}"
+            lines.append(prefix)
             lines.extend(walk(children, indent + 1))
         return lines
 


### PR DESCRIPTION
## Summary
- append document URLs in tree view
- document this behavior in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c2a8b3070832aa384850d4e1f52fa