### PR TITLE
Implement unique attachment filenames

### DIFF
--- a/backlog_document_exporter/client.py
+++ b/backlog_document_exporter/client.py
@@ -162,7 +162,9 @@ class BacklogClient:
 
         Uses ``GET /api/v2/documents/:documentId/attachments/:attachmentId``.
         ``filename`` can be supplied to override the name derived from
-        ``Content-Disposition``.
+        ``Content-Disposition``. If a file with the same name already exists in
+        ``output_dir``, ``_1``, ``_2`` and so on are appended before the file
+        extension so that existing files are not overwritten.
         """
 
         response = self._request(
@@ -176,7 +178,13 @@ class BacklogClient:
         if not filename:
             filename = parsed_name or str(attachment_id)
 
+        base, ext = os.path.splitext(filename)
         path = os.path.join(output_dir, filename)
+        counter = 1
+        while os.path.exists(path):
+            path = os.path.join(output_dir, f"{base}_{counter}{ext}")
+            counter += 1
+
         with open(path, "wb") as f:
             f.write(response.content)
         return path


### PR DESCRIPTION
## Summary
- avoid overwriting attachments by suffixing duplicate names with incrementing numbers

## Testing
- `python -m compileall backlog_document_exporter`
- `python - <<'PY'
import os, tempfile
from backlog_document_exporter.client import BacklogClient
class DummyResp:
    headers={'Content-Disposition':'attachment; filename="test.txt"'}
    content=b'data'
BacklogClient._request=lambda *a,**k: DummyResp()
bc=BacklogClient('space','key','proj')
tmp=tempfile.mkdtemp()
print(os.path.basename(bc.download_attachment('d',1,tmp,filename='file.txt')))
print(os.path.basename(bc.download_attachment('d',1,tmp,filename='file.txt')))
PY`

------
https://chatgpt.com/codex/tasks/task_e_684c2c0c9368832a99d8707876ca8628