### PR TITLE
Add export command

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ python3 -m backlog_document_exporter.cli list
 python3 -m backlog_document_exporter.cli tree
 python3 -m backlog_document_exporter.cli info <document_id>
 python3 -m backlog_document_exporter.cli download <document_id> [output_dir]
+python3 -m backlog_document_exporter.cli export [output_dir]
 ```
 
 If `output_dir` is omitted, files are saved to the current directory.
@@ -45,6 +46,8 @@ https://BACKLOG_SPACE_DOMAIN/document/BACKLOG_PROJECT_KEY/<document_id>
 The `tree` command prints a hierarchical view of the documents and appends the same URL after each document title.
 
 `<document_id>` is the identifier shown in the list or tree output. All command output other than downloaded files is printed in Markdown.
+
+The `export` command downloads all documents in the current project, recreating the document tree as directories. Each document's content is saved as `document.md` alongside any attachments.
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The `tree` command prints a hierarchical view of the documents and appends the s
 
 `<document_id>` is the identifier shown in the list or tree output. All command output other than downloaded files is printed in Markdown.
 
-The `export` command downloads all documents in the current project, recreating the document tree as directories. Each document's content is saved as `document.md` alongside any attachments.
+The `export` command downloads all documents in the current project, recreating the document tree as directories. Each document's metadata and content are saved to `document.md` alongside any attachments.
 
 ## Reference
 

--- a/backlog_document_exporter/cli.py
+++ b/backlog_document_exporter/cli.py
@@ -119,6 +119,8 @@ def export_all_documents(client: BacklogClient, output_dir: str = ".") -> None:
         info = client.get_document_info(doc_id)
         content = info.get("content") or info.get("text") or ""
         with open(os.path.join(dir_path, "document.md"), "w", encoding="utf-8") as f:
+            f.write(_dict_to_markdown(info))
+            f.write("\n\n")
             f.write(content)
         download_attachments(client, doc_id, dir_path)
 

--- a/backlog_document_exporter/cli.py
+++ b/backlog_document_exporter/cli.py
@@ -3,6 +3,8 @@ import json
 import os
 from typing import Any, Dict, List
 
+from tqdm import tqdm
+
 from .client import BacklogClient
 
 
@@ -82,6 +84,45 @@ def download_attachments(
         print(f"Downloaded {att['name']} -> {path}")
 
 
+def safe_name(name: str) -> str:
+    """Return a filesystem-safe name."""
+    return "".join("_" if c in "\\/" else c for c in name)
+
+
+def export_all_documents(client: BacklogClient, output_dir: str = ".") -> None:
+    print("Fetching document tree...")
+    project_id = client.get_project_id()
+    tree = client.get_document_tree(project_id)
+
+    nodes = tree.get("activeTree", {}).get("children", [])
+    docs: List[tuple[str, List[str]]] = []
+
+    def gather(nodes: List[Dict[str, Any]], path: List[str]) -> None:
+        for node in nodes:
+            name = safe_name(node.get("name", ""))
+            children = node.get("children", [])
+            new_path = path + [name]
+            if "id" in node:
+                docs.append((str(node["id"]), new_path))
+            if children:
+                gather(children, new_path)
+
+    gather(nodes, [])
+
+    print(f"Creating directory tree at {output_dir}...")
+    for _, parts in docs:
+        os.makedirs(os.path.join(output_dir, *parts), exist_ok=True)
+
+    print("Downloading documents...")
+    for doc_id, parts in tqdm(docs, desc="Documents", unit="doc"):
+        dir_path = os.path.join(output_dir, *parts)
+        info = client.get_document_info(doc_id)
+        content = info.get("content") or info.get("text") or ""
+        with open(os.path.join(dir_path, "document.md"), "w", encoding="utf-8") as f:
+            f.write(content)
+        download_attachments(client, doc_id, dir_path)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Backlog Document Exporter")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -101,6 +142,16 @@ def main() -> None:
         help="Output directory (default: current directory)",
     )
 
+    export_all = subparsers.add_parser(
+        "export", help="Export all documents and attachments"
+    )
+    export_all.add_argument(
+        "output",
+        nargs="?",
+        default=".",
+        help="Output directory (default: current directory)",
+    )
+
     args = parser.parse_args()
 
     client = BacklogClient.from_env()
@@ -113,6 +164,8 @@ def main() -> None:
         print_document_info(client, args.document_id)
     elif args.command == "download":
         download_attachments(client, args.document_id, args.output)
+    elif args.command == "export":
+        export_all_documents(client, args.output)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 python-dotenv
+tqdm


### PR DESCRIPTION
## Summary
- add tqdm as a dependency
- implement `export` command to download all documents
- document new command in README

## Testing
- `pip install -r requirements.txt`
- `python3 -m backlog_document_exporter.cli -h`
- `python3 -m backlog_document_exporter.cli export -h`


------
https://chatgpt.com/codex/tasks/task_e_684c2d4fe4d4832abb6b3a868f9acab4